### PR TITLE
Slice 10 (AFK): Deployment + operations runbooks — the last slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@ Four independent deliverables for managing Dynamics 365 opportunities at Lenovo:
 
 See `docs/CONTEXT.md` for the full glossary and project invariants, `docs/adr/` for architectural decisions, and `PRD issue #2` for the full roadmap.
 
+## Documentation map
+
+### For the person deploying (one-time)
+
+1. [docs/deployment/aad-setup.md](./docs/deployment/aad-setup.md) — identity admin: AAD app + FIC
+2. [docs/deployment/dataverse-setup.md](./docs/deployment/dataverse-setup.md) — D365 admin: application user + role
+3. [docs/deployment/bicep-deploy.md](./docs/deployment/bicep-deploy.md) — platform engineer: Bicep deploy + code zip
+4. [docs/deployment/preflight.md](./docs/deployment/preflight.md) — anyone: `scripts/preflight.py` validates the chain end-to-end
+
+### For the person operating (ongoing)
+
+- [docs/operations/troubleshooting.md](./docs/operations/troubleshooting.md) — symptom → cause → diagnostic → remediation
+- [docs/operations/monitoring.md](./docs/operations/monitoring.md) — Bicep-deployed alerts + KQL queries for investigation
+- [docs/operations/secret-rotation.md](./docs/operations/secret-rotation.md) — FIC / MI / role / Foundry SP rotation (WIF means "almost nothing to rotate")
+
+### For the person extending the codebase
+
+- [docs/CONTEXT.md](./docs/CONTEXT.md) — invariants + glossary
+- [docs/adr/](./docs/adr/) — architectural decisions; read 0001–0007 in order
+- [infra/README.md](./infra/README.md) — Bicep layout + post-deploy checklist
+
 ## Current state
 
 The repo is mid-refactor: the legacy monolithic demo (`agent.py` + `skills/crm-opportunity/`) still runs unchanged, while the new layered products land slice by slice (tracked in GitHub issues #3–#12).

--- a/docs/deployment/aad-setup.md
+++ b/docs/deployment/aad-setup.md
@@ -1,0 +1,97 @@
+# AAD Setup
+
+**Audience**: Lenovo's identity administrator. You execute this once per deployment target (dev, UAT, prod), **before** the Bicep deployment in [bicep-deploy.md](./bicep-deploy.md).
+
+**Output**: an AAD application registration with delegated Dataverse permissions and a Federated Identity Credential that trusts a Managed Identity — no long-lived client secret anywhere.
+
+**ADR references**: [0001 OBO with WIF](../adr/0001-obo-with-wif.md) explains why. [0003 Dual-cloud parity](../adr/0003-dual-cloud-parity.md) drives the `CLOUD_ENV`-specific values below.
+
+## 1. Register the AAD application
+
+```bash
+az ad app create \
+  --display-name "crm-agent-<env>" \
+  --sign-in-audience AzureADMyOrg
+```
+
+Record `appId` (this becomes `AAD_APP_CLIENT_ID` in the Bicep parameter file) and the tenant ID (`AAD_APP_TENANT_ID`).
+
+Create the corresponding service principal:
+
+```bash
+az ad sp create --id <appId>
+```
+
+## 2. Grant delegated Dynamics permission
+
+In the Entra portal → App registrations → your app → **API permissions**:
+
+1. Add a permission → **Dynamics CRM** → **Delegated permissions** → `user_impersonation`
+2. Grant admin consent
+
+Or via CLI:
+
+```bash
+az ad app permission add \
+  --id <appId> \
+  --api 00000007-0000-0000-c000-000000000000 \
+  --api-permissions 78ce3f0f-a1ce-49c2-8cde-64b5c0896db4=Scope
+az ad app permission admin-consent --id <appId>
+```
+
+## 3. Wire the Federated Identity Credential
+
+Bicep deploys a User-Assigned Managed Identity and emits its `principalId` as an output. After the Bicep deployment succeeds, register that MI as a FIC on this AAD app so OBO can use the MI as its `client_assertion`.
+
+**The FIC audience differs by cloud** (this is the single most common CN deployment mistake):
+
+| `CLOUD_ENV` | FIC audience |
+|---|---|
+| `global` | `api://AzureADTokenExchange` |
+| `china` | `api://AzureADTokenExchangeChina` |
+
+```bash
+MI_PRINCIPAL_ID=$(az deployment group show \
+  --resource-group <rg> \
+  --name <deployment-name> \
+  --query properties.outputs.managedIdentityPrincipalId.value -o tsv)
+
+# Construct the issuer URL from your tenant.
+TENANT_ID=<AAD_APP_TENANT_ID>
+ISSUER="https://login.microsoftonline.com/$TENANT_ID/v2.0"  # global
+# For china: ISSUER="https://login.partner.microsoftonline.cn/$TENANT_ID/v2.0"
+
+AUDIENCE="api://AzureADTokenExchange"          # global
+# For china: AUDIENCE="api://AzureADTokenExchangeChina"
+
+az ad app federated-credential create \
+  --id <appId> \
+  --parameters @- <<JSON
+{
+  "name": "crm-agent-mi",
+  "issuer": "$ISSUER",
+  "subject": "$MI_PRINCIPAL_ID",
+  "audiences": ["$AUDIENCE"]
+}
+JSON
+```
+
+## 4. Verify
+
+Run the pre-flight script from a shell with `AUTH_MODE=obo` set — see [preflight.md](./preflight.md). Expected output:
+
+```
+✓ token-acquisition            pass Entra issued a Dataverse-scoped access token
+✓ dataverse-whoami             pass Dataverse accepted the token as UserId=...
+```
+
+If `token-acquisition` fails with `AADSTS700213`, the FIC audience is wrong for the cloud. Cross-reference the table above.
+
+## 5. What to record for the project file
+
+Hand off to the platform engineer (for Bicep `parameters.*.json`):
+
+- `AAD_APP_CLIENT_ID` = `<appId>`
+- `AAD_APP_TENANT_ID` = `<tenantId>`
+- FIC wired and verified ✓
+- Dataverse application user created ✓ (next: [dataverse-setup.md](./dataverse-setup.md))

--- a/docs/deployment/bicep-deploy.md
+++ b/docs/deployment/bicep-deploy.md
@@ -1,0 +1,94 @@
+# Bicep Deployment
+
+**Audience**: Lenovo's platform engineer. Run after [aad-setup.md](./aad-setup.md) and [dataverse-setup.md](./dataverse-setup.md) are complete — Bicep sets up Azure resources but cannot create AAD apps or Dataverse users.
+
+**Output**: a running Function App serving the MCP server (and optionally the reference agent's `/api/chat`) in your target Azure cloud.
+
+## Before you start
+
+Have these handy:
+
+| Value | Where from |
+|---|---|
+| Resource group name (create if needed) | Your call; must exist in the target cloud / region |
+| `AAD_APP_CLIENT_ID` | [aad-setup.md](./aad-setup.md) step 1 |
+| `AAD_APP_TENANT_ID` | [aad-setup.md](./aad-setup.md) step 1 |
+| `DATAVERSE_URL` | D365 Admin Center → environment → URL |
+| `FOUNDRY_PROJECT_ENDPOINT` | Foundry portal → project → Overview (only if `ENABLE_REFERENCE_AGENT=true`) |
+| Cloud | `global` (Azure Public) or `china` (21Vianet) |
+
+## Edit the parameter file
+
+Open `infra/parameters.global.json` or `infra/parameters.china.json` and replace every `REPLACE*` placeholder.
+
+`CLOUD_ENV` inside the file must match the cloud you are logged into (`global` → `az cloud set --name AzureCloud`, `china` → `az cloud set --name AzureChinaCloud`). A mismatch deploys fine but produces a Function App that can never acquire a token.
+
+## Validate before deploying (recommended)
+
+```bash
+az deployment group what-if \
+  --resource-group <your-rg> \
+  --template-file infra/main.bicep \
+  --parameters infra/parameters.global.json
+```
+
+Review the output. **Resources marked `Delete`** mean the deployment will remove pre-existing resources — make sure that's intentional (usually only a concern when redeploying into a used RG).
+
+## Deploy
+
+```bash
+az deployment group create \
+  --resource-group <your-rg> \
+  --name crm-agent-<env>-$(date +%Y%m%d-%H%M) \
+  --template-file infra/main.bicep \
+  --parameters infra/parameters.global.json
+```
+
+Record the deployment name; you'll use it to read outputs in a moment.
+
+## Wire the Federated Identity Credential
+
+The Bicep emits the Managed Identity's `principalId` as an output, but cannot create the FIC on the AAD app (which lives in Entra, not in the subscription). Loop back to [aad-setup.md](./aad-setup.md) step 3 now with that output in hand:
+
+```bash
+az deployment group show \
+  --resource-group <your-rg> \
+  --name <deployment-name> \
+  --query properties.outputs.managedIdentityPrincipalId.value -o tsv
+```
+
+## Zip-deploy the Function App code
+
+```bash
+# From the repo root:
+zip -r /tmp/crm-agent.zip . -x ".venv/*" ".git/*" "tests/*" "docs/*"
+
+az functionapp deployment source config-zip \
+  --resource-group <your-rg> \
+  --name $(az deployment group show -g <your-rg> -n <deployment-name> --query properties.outputs.functionAppName.value -o tsv) \
+  --src /tmp/crm-agent.zip
+```
+
+Wait ~60 seconds for the first cold start, then:
+
+```bash
+python scripts/preflight.py
+```
+
+Expected — four green ticks. If any fail, the output's `remediation:` line names the concrete next step; cross-reference [troubleshooting.md](../operations/troubleshooting.md) for deeper help.
+
+## Cost note
+
+Consumption plan (Y1) + Log Analytics (PerGB2018, 30-day retention) + App Insights + default alerts runs **under ~$10/month at 100 calls/day**. LLM inference (Foundry) is separate and billed by token per your deployment.
+
+## Redeploy
+
+Redeploys are idempotent — re-run the same command. The `name` timestamp means each deployment has its own record in the RG's deployment history (useful for rollback auditing).
+
+## Tear down
+
+```bash
+az group delete --resource-group <your-rg>
+```
+
+Does not remove the AAD app or the Dataverse application user — both are in separate tenants / environments.

--- a/docs/deployment/dataverse-setup.md
+++ b/docs/deployment/dataverse-setup.md
@@ -1,0 +1,58 @@
+# Dataverse Setup
+
+**Audience**: Lenovo's Dynamics 365 administrator. Execute after [aad-setup.md](./aad-setup.md) has registered the AAD application.
+
+**Output**: a Dataverse **application user** that the MCP server calls Dataverse as, with a security role granting the **Delegate** privilege so OBO works.
+
+## Why an application user
+
+OBO means the MCP server acts on behalf of the real end user. That still requires the AAD app to be **a known principal inside Dataverse** — an "application user" record linked to the AAD app's client ID. Without it, Dataverse rejects even a perfectly valid Entra token with `401` or `403`.
+
+## Create the application user
+
+D365 Admin Center is the supported path; there is no Bicep / Graph equivalent.
+
+1. Go to [https://admin.powerplatform.microsoft.com](https://admin.powerplatform.microsoft.com) (or [https://admin.powerplatform.microsoft.cn](https://admin.powerplatform.microsoft.cn) in China)
+2. **Environments** → pick your environment → **Settings** → **Users + permissions** → **Application users** → **+ New app user**
+3. **+ Add an app** → search for the AAD app's client ID (from [aad-setup.md](./aad-setup.md)'s step 1)
+4. **Business unit**: pick the root business unit unless Lenovo's Dataverse admin tells you otherwise
+5. Click **Create**
+
+## Assign a security role
+
+The default new application user has **no privileges**. Without at least one security role granting the **Delegate** privilege (`prvActOnBehalfOfAnotherUser`), OBO calls return 403 at the Dataverse boundary.
+
+Lenovo-approved options:
+
+- **Delegate** (built-in) — grants only `prvActOnBehalfOfAnotherUser`. Minimal, recommended.
+- A custom role cloned from **Delegate** + whatever additional read/write Lenovo's data governance team approves. Required if the application user itself also needs to read/write data directly (which it should NOT with pure OBO — OBO runs as the real user and uses the user's privileges).
+
+Assign in the same admin UI: the application user row → **Manage roles** → tick the chosen role → **Save**.
+
+## Verify
+
+```bash
+python scripts/preflight.py
+```
+
+Expected:
+
+```
+✓ dataverse-whoami             pass Dataverse accepted the token as UserId=<GUID>
+```
+
+The `<GUID>` echoed back is the Dataverse **systemuser.SystemUserId** of the application user you just created. Confirm it matches what D365 Admin Center shows — a mismatch means a different application user than expected is handling the calls.
+
+## Common failure modes
+
+| preflight output | Probable cause | Fix |
+|---|---|---|
+| `Dataverse returned 401` | Application user does not exist, OR AAD app `client_id` != the one the user is linked to | Re-check step 3 in D365 Admin Center |
+| `Dataverse returned 403` | Application user exists but has no Delegate-capable role | Assign the Delegate role (step 2) |
+| `Dataverse returned 404` for WhoAmI | `DATAVERSE_URL` points at the wrong environment | Fix the parameter file; the env's URL is visible in the admin portal |
+
+## What to record
+
+- Application user created ✓ (note the SystemUserId for the operations handoff)
+- Security role assigned ✓ (note the role name)
+- Preflight's `dataverse-whoami` check passes ✓

--- a/docs/deployment/preflight.md
+++ b/docs/deployment/preflight.md
@@ -1,0 +1,56 @@
+# Pre-flight Validation
+
+**Audience**: anyone who just changed configuration (identity admin, D365 admin, platform engineer). Run before you believe a deployment is working.
+
+**Output**: four structured checks with pass / fail / skip — and for every fail, a `remediation:` line naming the concrete next step.
+
+`scripts/preflight.py` is the "delivered blind" gate (Invariant 4): the authors have no access to your Azure China tenant, so every failure that we can anticipate is encoded here. See [ADR 0007](../adr/0007-testing-discipline.md) for the full discipline.
+
+## Run
+
+```bash
+python scripts/preflight.py                # human-readable
+python scripts/preflight.py --format json  # machine-parseable
+```
+
+Required env vars (or `.env` entries):
+
+| Variable | Value |
+|---|---|
+| `CLOUD_ENV` | `global` or `china` |
+| `AUTH_MODE` | `obo` in production, `app_only_secret` for dev |
+| `DATAVERSE_URL` | Your Dataverse environment URL |
+| `AAD_APP_CLIENT_ID` / `AAD_APP_TENANT_ID` | From [aad-setup.md](./aad-setup.md) |
+| `FOUNDRY_PROJECT_ENDPOINT` / `FOUNDRY_MODEL` | When `ENABLE_REFERENCE_AGENT=true` |
+
+When running **locally** from the repo, preflight auto-loads `skills/crm-opportunity/.env` and `.env` if present. In **production** (on the Function App) the env vars come from App Settings deployed by Bicep.
+
+## Expected output
+
+All green on a correctly configured deployment:
+
+```
+✓ dns-reachability             pass resolved 3 host(s): login.microsoftonline.com, ...
+✓ token-acquisition            pass Entra issued a Dataverse-scoped access token
+✓ dataverse-whoami             pass Dataverse accepted the token as UserId=<GUID>
+✓ foundry-reachability         pass Foundry returned a reply (33 chars)
+
+4 passed · 0 failed · 0 skipped
+```
+
+## Failure → remediation
+
+The full remediation tree lives in the code (`src/preflight/checks.py`), but here's the quick map:
+
+| Failing check | Most common cause | First thing to try |
+|---|---|---|
+| `dns-reachability` | Private DNS zone / firewall egress missing for the Function App | Verify name resolution from **inside** the Function App's VNet (if integrated); check hub-spoke Private Endpoint wiring |
+| `token-acquisition` | AAD app missing, wrong `AZURE_CLIENT_SECRET`, or **wrong FIC audience for the cloud** | Compare the FIC audience against [aad-setup.md](./aad-setup.md) step 3 table; look for an `AADSTS` code in the `detail:` line |
+| `dataverse-whoami` | Dataverse application user not created, OR missing Delegate privilege | Re-walk [dataverse-setup.md](./dataverse-setup.md); the `detail:` line's HTTP code distinguishes these (401 vs 403) |
+| `foundry-reachability` | Cross-tenant credential, missing `Cognitive Services User` role, or wrong `FOUNDRY_MODEL` | See [infra/README.md](../../infra/README.md) post-deploy step 3 for the cross-tenant SP pattern |
+
+Never skipped in prod: any check in `skip` state on a `Production` environment points to misconfiguration (usually `ENABLE_REFERENCE_AGENT=false` silently failing a check that should have run).
+
+## In CI
+
+`tests/integration/test_preflight_live.py` runs `scripts/preflight.py` as a subprocess on every PR against the author's Azure Global dev tenant (ADR 0007). If the test fails on a PR that does not touch preflight, the dev environment has drifted and needs human investigation before merging.

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,98 @@
+# Monitoring
+
+**Audience**: on-call / SRE. Every query below runs against the Application Insights resource deployed by `infra/modules/monitoring.bicep`. The Bicep-deployed **alerts** in `infra/modules/alerts.bicep` already cover the critical cases; these queries are for ad-hoc investigation.
+
+**Workspace-based App Insights** is mandatory (ADR 0002 rejects the deprecated classic mode). Every `requests` / `traces` / `dependencies` query here runs identically on Azure Global and Azure China.
+
+## Deployed alerts (Bicep)
+
+| Rule name | Severity | Trigger |
+|---|---|---|
+| `crm-agent-alert-http-5xx` | 2 | Any 5xx in 5m |
+| `crm-agent-alert-p95-latency` | 3 | p95 > 10s for 5m (over 15m window) |
+| `crm-agent-alert-auth-failure` | 2 | > 5 requests with HTTP 401 in 5m |
+| `crm-agent-alert-chat-4xx` | 2 | > 3 requests to `/api/chat` with 4xx in 10m (only if `ENABLE_REFERENCE_AGENT=true`) |
+
+All alerts fire to the optional action group passed in as a Bicep parameter. If none is set, alerts stay visible in Monitor but don't page — intentional so the stack comes up without a blocking dependency on ticketing / PagerDuty integration.
+
+## Canonical KQL queries
+
+### User-OID + request-ID correlation (US 30)
+
+Every request the agent makes to MCP carries a correlation chain. This query joins them by `operation_Id`:
+
+```kusto
+requests
+| where timestamp > ago(1h)
+| where url endswith "/api/chat" or url endswith "/mcp/"
+| extend user_oid = tostring(customDimensions["user_oid"])
+| project timestamp, operation_Id, url, resultCode, user_oid, duration
+| order by timestamp desc
+```
+
+To follow a specific incident, add `| where operation_Id == "<id from the user's error message>"`.
+
+### Tool-call latency breakdown (agent → MCP → Dataverse)
+
+```kusto
+dependencies
+| where timestamp > ago(1h)
+| where name startswith "POST " and target endswith ".crm.dynamics.com"
+    or target endswith ".crm.dynamics.cn"
+    or target contains "services.ai.azure"
+| summarize p50 = percentile(duration, 50), p95 = percentile(duration, 95),
+            p99 = percentile(duration, 99), count()
+  by bin(timestamp, 5m), target
+| render timechart
+```
+
+### Top error sources (last 24h)
+
+```kusto
+requests
+| where timestamp > ago(24h)
+| where success == false
+| summarize count() by name, resultCode, bin(timestamp, 1h)
+| order by count_ desc
+```
+
+### Token-cache hit rate
+
+The MCP server caches per-user Dataverse tokens; low hit rate means the cache TTL is wrong or the caller is using a fresh JWT per call (which undermines Invariant 2's production-grade commitment).
+
+```kusto
+traces
+| where timestamp > ago(1h)
+| where message startswith "auth.token_cache"
+| summarize hits = countif(message == "auth.token_cache.hit"),
+            misses = countif(message == "auth.token_cache.miss")
+            by bin(timestamp, 5m)
+| extend hit_rate = todouble(hits) / todouble(hits + misses)
+| render timechart
+```
+
+### Foundry token usage (cost estimation)
+
+```kusto
+traces
+| where timestamp > ago(24h)
+| where message startswith "usage."
+| extend tokens = toint(customDimensions["total_tokens"])
+| summarize total_tokens = sum(tokens), calls = count()
+  by bin(timestamp, 1h), model = tostring(customDimensions["model"])
+| render timechart
+```
+
+## Dashboard starter
+
+The Bicep deployment does not include a pre-built workbook — they are customer-environment-specific. Recommended panels:
+
+1. **Request volume** — `requests | summarize count() by bin(timestamp, 5m), name | render timechart`
+2. **Failure rate** — `requests | summarize failures = countif(success == false), total = count() by bin(timestamp, 5m) | extend rate = todouble(failures) / todouble(total)`
+3. **p95 response time** per route — the dependencies query above, grouped by `name`
+4. **Users active today** — `requests | where timestamp > startofday(now()) | distinct tostring(customDimensions["user_oid"])`
+5. **Current alert state** — link out to `aka.ms/azuremonitor/alerts` filtered by resource group
+
+## Lenovo landing zone integration
+
+When running inside Lenovo's landing zone, the Log Analytics workspace may be pre-provisioned and the Bicep should be updated to reference it rather than create a new one. See the `monitoring.bicep` module for the attachment point — a parameter can be added to accept an existing workspace resource ID.

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -1,0 +1,134 @@
+# Secret Rotation
+
+**Audience**: SRE / platform engineer. Fulfils US 31 — every credential this system relies on has a documented rotation procedure, even when the credential is "there is no credential" (WIF).
+
+## What this system does NOT have to rotate
+
+Per [ADR 0001](../adr/0001-obo-with-wif.md), production explicitly eliminates long-lived client secrets. The runtime has:
+
+- **No `AZURE_CLIENT_SECRET`** in production (`AUTH_MODE=obo` refuses to boot under it)
+- **No Key Vault-stored secret** — Bicep doesn't deploy one
+- **No connection-string secret** — Storage uses Managed Identity; App Insights uses connection string but that's a telemetry pointer, not a credential
+
+What DOES need periodic attention:
+
+## 1. Federated Identity Credential
+
+**What it is**: the trust relationship linking a Managed Identity to the AAD app, allowing OBO without a client secret.
+
+**Lifecycle**: FICs don't expire on their own. Rotation is only needed when:
+
+- The Managed Identity is recreated (e.g. deleting the RG and redeploying) — the new MI has a new `principalId`, so the old FIC no longer matches
+- Compromise is suspected — delete + recreate forces re-issuance
+
+**Rotate**:
+
+```bash
+# List existing FICs on the AAD app
+az ad app federated-credential list --id <appId>
+
+# Delete the stale one
+az ad app federated-credential delete --id <appId> --federated-credential-id <fic-id>
+
+# Recreate against the new MI principal — re-walk aad-setup.md step 3
+```
+
+No downtime window: preflight shows `token-acquisition` fail during the gap, but outbound user requests fail closed rather than leaking.
+
+## 2. Managed Identity
+
+**What it is**: the Azure-managed principal the Function App runs as.
+
+**Lifecycle**: MIs don't have rotatable credentials by design — that's the whole point of WIF. The MI's internal tokens rotate automatically on every `get_token()`.
+
+**Replacement** (rare — only when changing MI assignment, not really "rotation"):
+
+```bash
+# Detach the current MI from the Function App
+az functionapp identity remove \
+  --resource-group <rg> \
+  --name <function-app-name> \
+  --identities <current-mi-resource-id>
+
+# Attach a new one — usually via redeploying Bicep with the new identity resource
+az deployment group create ...
+```
+
+Remember to recreate the FIC against the new MI's `principalId` afterwards (see section 1).
+
+## 3. Dataverse security role
+
+**What it is**: the Delegate-capable security role assigned to the AAD application user.
+
+**Lifecycle**: role membership persists until explicitly removed in D365 Admin Center. Lenovo's access-governance policy may require periodic re-attestation (typically quarterly).
+
+**Re-attest**:
+
+1. D365 Admin Center → environment → Users + permissions → Application users
+2. Find the AAD app's application user
+3. Manage roles → confirm the Delegate role is still assigned with the correct scope
+4. Evidence the audit: screenshot, or export with `az dataverse ...`
+
+**Change the role** (e.g. tightening privileges): assign the new role, verify preflight's `dataverse-whoami` still passes, then remove the old role. Do it in that order so there's never a window where the application user has zero roles.
+
+## 4. Foundry service principal (when cross-tenant)
+
+Applies only when Foundry is in a different tenant from the Function App's MI — the setup documented in `infra/README.md` and `tests/integration/test_foundry_live.py`.
+
+**What it is**: `FOUNDRY_AZURE_TENANT_ID` / `FOUNDRY_AZURE_CLIENT_ID` / `FOUNDRY_AZURE_CLIENT_SECRET`, stored as App Settings on the Function App and as GitHub repo secrets for CI.
+
+**Lifecycle**: this IS a long-lived client secret by necessity (cross-tenant RBAC limitation, not a design choice we made). Entra supports client secrets up to 2 years; Lenovo's policy may require shorter.
+
+**Rotate** (example: every 90 days):
+
+```bash
+# Create a new secret, keep the old one active during the swap
+NEW_SECRET=$(az ad app credential reset \
+  --id <foundry-sp-appid> \
+  --display-name "crm-agent-rotation-$(date +%Y%m%d)" \
+  --query password -o tsv)
+
+# Push the new value into the Function App
+az functionapp config appsettings set \
+  --resource-group <rg> \
+  --name <function-app-name> \
+  --settings "FOUNDRY_AZURE_CLIENT_SECRET=$NEW_SECRET"
+
+# Verify it works
+python scripts/preflight.py  # foundry-reachability must pass
+
+# Now remove the OLD secret (get the keyId from `az ad app credential list`)
+az ad app credential delete --id <foundry-sp-appid> --key-id <old-secret-keyid>
+
+# Update GitHub repo secret FOUNDRY_AZURE_CLIENT_SECRET with $NEW_SECRET
+```
+
+## 5. GitHub Actions secrets
+
+Used only in CI, not in production. Every secret listed in `.github/workflows/ci.yml` has the same rotation cadence as its Azure source of truth:
+
+| Secret | Source | Rotate with |
+|---|---|---|
+| `AZURE_CLIENT_SECRET` | Dataverse SP | Section 2 of this doc (when Dataverse SP rotates) |
+| `FOUNDRY_AZURE_CLIENT_SECRET` | Foundry SP | Section 4 |
+| `AZURE_BICEP_*` (OIDC) | Federated credential | `az ad app federated-credential` on the Bicep CI app — similar pattern to section 1 |
+
+GitHub's UI: Settings → Secrets and variables → Actions.
+
+## Rotation schedule (recommended)
+
+| Item | Frequency | Triggered automatically? |
+|---|---|---|
+| FIC | Never (unless MI changes) | No |
+| MI | Never (tokens auto-rotate inside Azure) | Yes (internal) |
+| Dataverse role re-attestation | Quarterly | No (compliance check) |
+| Foundry SP secret (when cross-tenant) | ≤ 90 days | No |
+| GitHub Actions secrets | With their source | No |
+
+## Verification after any rotation
+
+```bash
+python scripts/preflight.py
+```
+
+If any check fails, roll back the change and investigate before proceeding — partial credentials are worse than old ones.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,47 @@
+# Troubleshooting
+
+**Audience**: on-call / SRE / platform engineer triaging a reported problem. Every row of the table below names both Azure Global and Azure China failure modes where they differ — per US 22.
+
+**First line of defence**: run [scripts/preflight.py](../deployment/preflight.md) before touching anything. Its structured output covers most of the table below with concrete `remediation:` lines.
+
+## MCP-side problems
+
+| Symptom | Most likely cause | Diagnostic | Remediation |
+|---|---|---|---|
+| External MCP client cannot list tools | Authorization header missing or invalid | App Insights → requests where `url endswith "/mcp/" and resultCode == 401` | Verify the caller is sending `Authorization: Bearer <token>` with an audience matching `AAD_APP_CLIENT_ID` |
+| `list_opportunities` returns empty for everyone | Dataverse app user has no read privilege on opportunities | `dataverse-whoami` in preflight passes, but tool calls return `[]` | Assign a security role on the application user that grants `prvReadOpportunity`; re-check [dataverse-setup.md](../deployment/dataverse-setup.md) |
+| `list_opportunities` returns fewer records than expected | Row-level security filtering (expected with OBO) | Compare what the calling user sees in D365 UI directly | Not a bug — this is Invariant 1's intended behaviour. If the user should see more, fix their team / business unit membership in Dataverse, not in the MCP server |
+| 5xx on every call | Function App ran out of memory or hit a cold-start retry storm | Function App → Metrics → `MemoryWorkingSet` + `HttpResponseTime` | Upgrade to Premium or Flex Consumption plan if 100/day is being exceeded (Consumption has been the design target; revisit per [ADR 0002](../adr/0002-self-hosted-mcp-sdk.md)) |
+| `token-acquisition` fails intermittently | Entra rate limit or MSAL cache corruption | preflight error says `AADSTS50196` (rate limit) | Usually self-heals in 60s; if persistent, restart the Function App to clear the in-memory MSAL cache |
+| `token-acquisition` fails with `AADSTS700213` | **FIC audience mismatch for the cloud** | preflight `detail:` line carries the code | Recreate the FIC with the correct audience for `CLOUD_ENV` (see [aad-setup.md](../deployment/aad-setup.md) step 3); Global uses `api://AzureADTokenExchange`, China uses `api://AzureADTokenExchangeChina` |
+| DNS resolution fails for `login.microsoftonline.com` (global) or `login.partner.microsoftonline.cn` (china) | Private DNS zone or firewall egress rule missing | preflight `dns-reachability` fails; `nslookup` from inside the VNet confirms | Add the authority host to the Function App's outbound allowlist; in China, confirm the Private DNS zone link targets the 21Vianet fabric, not Global |
+| Slow every call, not just first one | Consumption plan is rotating cold starts every few minutes (low usage pattern) | App Insights p95 latency > 1s sustained | Switch to Flex Consumption for a warm always-on worker; budget impact per [bicep-deploy.md](../deployment/bicep-deploy.md) |
+
+## Agent-side (`/api/chat`) problems
+
+Skip this section if `ENABLE_REFERENCE_AGENT=false`.
+
+| Symptom | Most likely cause | Diagnostic | Remediation |
+|---|---|---|---|
+| `/api/chat` returns 401 | User JWT missing or has wrong audience | App Insights request's `customDimensions` lacks `user_oid` | Verify the UI sends `Authorization: Bearer <user-jwt>` with audience = the AAD app's Application ID URI |
+| `/api/chat` returns 404 | `ENABLE_REFERENCE_AGENT=false` (agent route not mounted) | App Settings in Function App | Set `ENABLE_REFERENCE_AGENT=true` and restart; redeploy Bicep if the app setting itself is gone |
+| Agent returns "no tools available" | `MCP_SERVER_URL` wrong or self-call fails | App Insights → request chain shows the `/mcp` initialize POST failing | Confirm `MCP_SERVER_URL` is the Function App's own public URL + `/mcp`; Bicep sets it from `defaultHostName` but a manual env-var override would break it |
+| Stream stalls mid-response | Foundry deployment overloaded or quota exhausted | App Insights → dependencies → `Http Response Time` on the Foundry call | Preflight `foundry-reachability` catches the common cases; for quota, check Azure AI Foundry portal → Usage |
+| LLM repeatedly calls tools without finishing | Compaction strategy evicting key context | App Insights → `customDimensions.compaction_evictions > 0` | Increase `SlidingWindowStrategy(keep_last_groups=...)` in `src/agent/builder.py`; this is a tuning parameter per deployment |
+| Agent skips approval for destructive ops | `approval_mode` not wired correctly | `src/agent/builder.py` inspection | Verify `approval_mode={"always_require_approval": ["delete_opportunity"]}`; integration test `test_builder` should catch regressions at PR time |
+| `/api/chat` 4xx spike on `/api/chat` | UI is sending malformed payloads | The `crm-agent-alert-chat-4xx` alert fires | Check App Insights → requests → resultCode startswith "4" → customDimensions for the failing request body |
+
+## Cross-cloud traps
+
+| Global uses | China uses | Where wrong value surfaces |
+|---|---|---|
+| `login.microsoftonline.com` | `login.partner.microsoftonline.cn` | preflight `token-acquisition` fail with a connection timeout |
+| `api://AzureADTokenExchange` | `api://AzureADTokenExchangeChina` | preflight `token-acquisition` fail with `AADSTS700213` |
+| `*.crm.dynamics.com` | `*.crm.dynamics.cn` | preflight `dataverse-whoami` 404 or timeout |
+| `*.azurewebsites.net` | `*.chinacloudsites.cn` | `MCP_SERVER_URL` wrong after Bicep output substitution — Bicep reads the Function App's `defaultHostName` so this should be automatic; if wrong, the Function App's outbound-only Private Endpoint is likely misconfigured |
+
+## Where to look next
+
+- `src/preflight/checks.py` — each check's `remediation` string is authoritative
+- `docs/operations/monitoring.md` — KQL queries for the requests / dependencies tables
+- `docs/operations/secret-rotation.md` — FIC / MI / role-assignment rotation mechanics

--- a/tests/test_docs_integrity.py
+++ b/tests/test_docs_integrity.py
@@ -1,0 +1,79 @@
+"""Meta-test: runbook hyperlinks must point at files that actually exist.
+
+Documentation rot is the largest risk of shipping runbooks — a refactor
+that renames `src/preflight/checks.py` without touching `docs/deployment/
+preflight.md` means the customer opens a broken link on day one at UAT,
+which Invariant 4 (delivered blind) makes unrecoverable.
+
+This test walks every Markdown file under `docs/` and asserts that every
+`[text](path)` link whose destination looks like a repo path resolves.
+We intentionally skip backtick-wrapped content and other mentions —
+they are too noisy (hostnames, globs, enum values, code snippets) and
+rarely represent broken navigation.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+_REPO = Path(__file__).resolve().parents[1]
+_DOCS = _REPO / "docs"
+
+# Match the destination of a markdown link: `[visible text](dest)`.
+_LINK_PATTERN = re.compile(r"\]\(([^)]+)\)")
+
+# Skip these prefixes — they're external and not our job to validate.
+_EXTERNAL_PREFIXES = ("http://", "https://", "mailto:")
+
+
+def _all_doc_files() -> list[Path]:
+    return sorted(_DOCS.rglob("*.md"))
+
+
+def _resolve_candidate(doc: Path, candidate: str) -> Path | None:
+    """Resolve a link destination to an absolute path inside the repo, or
+    return None if it's not a repo path we should validate."""
+    # Drop anchor + query fragments.
+    candidate = candidate.split("#", 1)[0].split("?", 1)[0].strip()
+    if not candidate:
+        return None
+    if candidate.startswith(_EXTERNAL_PREFIXES):
+        return None
+
+    if candidate.startswith("/"):
+        # Repo-absolute. Strip the leading slash.
+        resolved = (_REPO / candidate.lstrip("/")).resolve()
+    else:
+        # Relative to the doc's directory.
+        resolved = (doc.parent / candidate).resolve()
+
+    # Only validate if the result lands inside the repo (otherwise it's a
+    # path outside our control, e.g. a parent-of-repo file).
+    try:
+        resolved.relative_to(_REPO)
+    except ValueError:
+        return None
+    return resolved
+
+
+@pytest.mark.parametrize(
+    "doc", _all_doc_files(), ids=lambda p: str(p.relative_to(_REPO))
+)
+def test_markdown_links_in_doc_resolve(doc: Path):
+    text = doc.read_text(encoding="utf-8")
+    broken: list[str] = []
+    for match in _LINK_PATTERN.finditer(text):
+        resolved = _resolve_candidate(doc, match.group(1))
+        if resolved is None:
+            continue
+        if not resolved.exists():
+            broken.append(
+                f"{match.group(1)!r} → {resolved.relative_to(_REPO).as_posix()}"
+            )
+    assert not broken, (
+        f"{doc.relative_to(_REPO)} has broken internal links:\n  - "
+        + "\n  - ".join(broken)
+    )


### PR DESCRIPTION
Closes #12 — and with it, every slice in PRD #2.

## Summary

Ships the runbook set that closes the "delivered blind" loop: every piece of knowledge the authors have about standing up and operating this system is now written down in a place Lenovo's team will look.

**Seven runbooks**, each with a named audience at the top so the reader knows within three seconds whether they're in the right doc:

```
docs/
├── deployment/
│   ├── aad-setup.md          identity admin   (one-time)
│   ├── dataverse-setup.md    D365 admin       (one-time)
│   ├── bicep-deploy.md       platform eng     (per environment)
│   └── preflight.md          anyone           (after every change)
└── operations/
    ├── troubleshooting.md    on-call          (when something breaks)
    ├── monitoring.md         SRE              (weekly / investigation)
    └── secret-rotation.md    SRE              (per policy; WIF → most things don't rotate)
```

`README.md` gets a documentation map at the top so a first-time reader lands on the right runbook in one click.

## US coverage

- US 18 (AAD setup runbook) → `aad-setup.md`
- US 19 (Dataverse setup runbook) → `dataverse-setup.md`
- US 22 (error messages mention both cloud failure modes) → `troubleshooting.md` has a dedicated cross-cloud traps table
- US 30 (log correlation by user OID + request ID) → `monitoring.md` canonical KQL
- US 31 (runbook for monitoring queries, troubleshooting, secret rotation) → all three operations runbooks

## Meta-test: docs-integrity

`tests/test_docs_integrity.py` walks every Markdown file under `docs/` and asserts every `[text](path)` internal link resolves. Catches a future refactor that moves `src/preflight/checks.py` without updating `docs/deployment/preflight.md` — without this check, such a refactor lands a broken link into the UAT package where we can't recover it.

The test is scoped to Markdown links specifically; backtick-wrapped content (hostnames, globs, code snippets) is too noisy to validate automatically.

## Acceptance criteria (#12)

- [x] Every runbook has an explicit "audience" line naming the role it targets (check the top of each file)
- [x] Troubleshooting table covers both cloud failure modes for every cloud-sensitive entry (US 22)
- [x] Log-correlation section shows user-OID + request-ID KQL (`monitoring.md` → "User-OID + request-ID correlation")
- [x] Secret-rotation runbook covers FIC rotation, MI reassignment, role re-attestation, and Foundry SP rotation
- [x] `README.md` points at each runbook and the relevant ADRs
- [ ] **Dry-run acceptance**: a non-author teammate successfully deploys to a fresh `CLOUD_ENV=global` RG using only the runbooks — this is a customer / internal exercise, not something this PR can self-verify. Recommended before production signoff.

## Test plan

- [x] `pytest` → 108 passed + 4 skipped on Python 3.11.15 (+14 meta-test + 1 ignored for infrastructure)
- [x] Every internal `[text](path)` link in every runbook resolves (docs-integrity meta-test)

## What closes with this merge

Every slice in PRD #2 lands. Remaining open issue is only #2 itself, the PRD tracker — which stays open as project history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)