### PR TITLE
Slice 6 (AFK): LLM provider abstraction — azure-openai-global / cn / custom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,26 @@ MANAGED_IDENTITY_CLIENT_ID=
 # false -> /mcp/* only; use when a customer runs their own agent
 ENABLE_REFERENCE_AGENT=true
 
-# Selects the concrete AF chat client. Slice 2 ships `foundry`; other providers
-# wire in via Slice 6 (#8).
+# Selects the concrete AF chat client. Slice 6 ships four:
+#   foundry              — default; Azure AI Foundry project
+#   azure-openai-global  — Azure OpenAI on Global; needs AZURE_OPENAI_ENDPOINT
+#   azure-openai-cn      — Azure OpenAI on 21Vianet; same env vars
+#   custom               — dotted-path factory via CUSTOM_LLM_CLIENT_FACTORY
 LLM_PROVIDER=foundry
 
-# Azure AI Foundry project endpoint + deployed model.
+# Azure AI Foundry project endpoint + deployed model (when LLM_PROVIDER=foundry).
 FOUNDRY_PROJECT_ENDPOINT=
 FOUNDRY_MODEL=gpt-4o-mini
+
+# Azure OpenAI endpoint (when LLM_PROVIDER=azure-openai-global|cn).
+# Global: https://<resource>.openai.azure.com
+# China:  https://<resource>.openai.azure.cn
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_VERSION=2024-10-21
+
+# Custom provider (when LLM_PROVIDER=custom). Format: module.path:callable.
+# The callable takes no args and must return an agent_framework SupportsChatGetResponse.
+CUSTOM_LLM_CLIENT_FACTORY=
 
 # The reference agent calls the MCP server over HTTP (ADR 0004) even when
 # co-located in the same Function App. In Azure this is typically the app's

--- a/README.md
+++ b/README.md
@@ -81,12 +81,39 @@ All cloud-specific values are driven by `CLOUD_ENV` so that shipping to Azure Ch
 | Variable | Required | Description |
 |---|---|---|
 | `ENABLE_REFERENCE_AGENT` | No (default `true`) | `false` skips the `/api/chat` route entirely |
-| `LLM_PROVIDER` | No (default `foundry`) | Slice 2 ships `foundry` only; others land in #8 |
-| `FOUNDRY_PROJECT_ENDPOINT` | Yes (if agent enabled) | Foundry project base URL |
+| `LLM_PROVIDER` | No (default `foundry`) | `foundry` / `azure-openai-global` / `azure-openai-cn` / `custom` |
+| `FOUNDRY_PROJECT_ENDPOINT` | If `LLM_PROVIDER=foundry` | Foundry project base URL |
 | `FOUNDRY_MODEL` | No (default `gpt-4o-mini`) | Deployment name |
+| `AZURE_OPENAI_ENDPOINT` | If `LLM_PROVIDER=azure-openai-*` | Azure OpenAI endpoint; `.com` on Global, `.cn` on 21Vianet |
+| `AZURE_OPENAI_API_VERSION` | No (default `2024-10-21`) | |
+| `CUSTOM_LLM_CLIENT_FACTORY` | If `LLM_PROVIDER=custom` | Dotted path to a zero-arg factory that returns a `SupportsChatGetResponse` |
 | `MCP_SERVER_URL` | Yes (if agent enabled) | URL the agent posts to; typically the app's own `/mcp` endpoint |
 
 See `.env.example` for the full template.
+
+### Adding a new LLM provider
+
+The `LLM_PROVIDER=custom` path is a stable extension point. A customer integrates a model we never shipped support for by:
+
+1. Implementing an object with an `async def get_response(messages, *, stream=False, **kwargs)` method (matches AF's `SupportsChatGetResponse` protocol).
+2. Packaging it in an importable Python module.
+3. Setting `CUSTOM_LLM_CLIENT_FACTORY=your.module.path:factory_callable` where `factory_callable` takes no args and returns an instance.
+
+Minimal example:
+
+```python
+# your_org/llm/qwen.py
+class QwenChatClient:
+    async def get_response(self, messages, *, stream=False, **kwargs):
+        ...  # your implementation
+
+def make_qwen():
+    return QwenChatClient()
+```
+
+Then: `LLM_PROVIDER=custom` + `CUSTOM_LLM_CLIENT_FACTORY=your_org.llm.qwen:make_qwen`.
+
+Prompts that need to change per provider go under `src/agent/prompts/providers/{provider}.md` — the `PromptLoader` appends them to the base system prompt automatically when the matching provider is active (ADR 0006 / ADR 0005).
 
 ## Legacy demo (unchanged until later slices)
 

--- a/function_app.py
+++ b/function_app.py
@@ -75,9 +75,15 @@ def _build_reference_agent():
     from agent.prompts.loader import PromptLoader
 
     prompts_dir = Path(__file__).parent / "src" / "agent" / "prompts"
+    llm_provider = os.environ.get("LLM_PROVIDER", "foundry").strip().lower()
     return build_agent(
-        project_endpoint=_require_env("FOUNDRY_PROJECT_ENDPOINT"),
+        llm_provider=llm_provider,
+        project_endpoint=os.environ.get("FOUNDRY_PROJECT_ENDPOINT", ""),
         model=os.environ.get("FOUNDRY_MODEL", "gpt-4o-mini"),
+        azure_openai_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+        azure_openai_api_version=os.environ.get(
+            "AZURE_OPENAI_API_VERSION", "2024-10-21"
+        ),
         mcp_url=_require_env("MCP_SERVER_URL"),
         prompts=PromptLoader(prompts_dir=prompts_dir),
         credential=DefaultAzureCredential(),

--- a/src/agent/builder.py
+++ b/src/agent/builder.py
@@ -1,18 +1,25 @@
 """Reference agent builder — composes an `agent_framework.Agent` from its parts.
 
 ADR 0005 (amended) selects Microsoft Agent Framework as the orchestration
-runtime for the reference agent. The production-grade features Invariant 2
-requires (session memory, sliding-window compaction, middleware, approval
-flows) live inside AF; we compose provider + tool + prompt into an Agent
-instance and stream its output from `/api/chat`.
+runtime. The abstraction for "swap the LLM" is AF's own
+`SupportsChatGetResponse`; this module dispatches on `LLM_PROVIDER` to the
+matching concrete chat client, leaving the runtime / tool-loop / approval
+code identical across providers.
 
-Invariant 1 stays intact: MCP is consumed through AF's own
-`MCPStreamableHTTPTool`, which speaks the standard protocol. The MCP server
-module (`src/mcp_server.py`) has no AF-specific assumptions — any external
-MCP-compliant client can use it.
+Supported providers (Slice 6):
+- `foundry`              — `agent_framework.foundry.FoundryChatClient` (default)
+- `azure-openai-global`  — `agent_framework_openai.OpenAIChatClient` against Azure OpenAI on Global
+- `azure-openai-cn`      — same class against Azure OpenAI on 21Vianet
+- `custom`               — dotted-path factory in `CUSTOM_LLM_CLIENT_FACTORY`
+
+Invariant 1 stays intact: the MCP server is consumed through AF's own
+`MCPStreamableHTTPTool`, which speaks the standard protocol regardless of
+which chat client is picked.
 """
 from __future__ import annotations
 
+import importlib
+import os
 from contextvars import ContextVar
 from datetime import date
 from typing import Any
@@ -25,36 +32,36 @@ from agent.prompts.loader import PromptLoader
 
 
 # Set per-request by `/api/chat` before invoking the Agent. Read at tool-call
-# time by the header provider on the MCPStreamableHTTPTool so the MCP server
-# sees the inbound user JWT and OBO preserves end-user identity (ADR 0001).
+# time by the request-event hook on the MCP tool's httpx client so the MCP
+# server sees the inbound user JWT and OBO preserves end-user identity.
 current_user_jwt: ContextVar[str] = ContextVar("current_user_jwt")
 
 
-def bearer_header_provider(_kwargs: dict[str, Any]) -> dict[str, str]:
-    """Return the Authorization header for the current in-flight request.
+_SUPPORTED_PROVIDERS = (
+    "foundry",
+    "azure-openai-global",
+    "azure-openai-cn",
+    "custom",
+)
 
-    Publicly exposed for testability: reads `current_user_jwt` from the ambient
-    ContextVar at call time so each request forwards its own user JWT without
-    risk of bleed across concurrent callers.
-    """
+
+class UnsupportedLLMProviderError(ValueError):
+    """Raised when `llm_provider` is set to a value this build does not support."""
+
+
+def bearer_header_provider(_kwargs: dict[str, Any]) -> dict[str, str]:
+    """Return the Authorization header for the current in-flight request."""
     return {"Authorization": f"Bearer {current_user_jwt.get()}"}
 
 
 async def _bearer_request_hook(request: httpx.Request) -> None:
-    """httpx request-event hook that attaches `Authorization: Bearer <jwt>` to
-    every outbound MCP request.
-
-    We cannot rely on AF's own `header_provider` mechanism because it only fires
-    inside `MCPStreamableHTTPTool.call_tool` — the initial MCP `initialize`
-    handshake POST therefore goes out unauthenticated and is rejected by the
-    MCP server with 401. Attaching the bearer at the httpx layer covers every
-    request in the session (initialize, tools/list, call_tool, ...).
-    """
+    """httpx request-event hook that attaches Authorization on every outbound
+    MCP request. We cannot rely on AF's header_provider alone because it only
+    fires inside call_tool — the MCP `initialize` handshake goes out before
+    that and is rejected with 401 without this hook."""
     try:
         request.headers["Authorization"] = f"Bearer {current_user_jwt.get()}"
     except LookupError:
-        # Called outside a request context (e.g. startup probes). Leave the
-        # request unauthorised; the server will 401 and surface the error.
         return
 
 
@@ -65,33 +72,26 @@ def build_agent(
     mcp_url: str,
     prompts: PromptLoader,
     credential: Any,
+    llm_provider: str = "foundry",
+    azure_openai_endpoint: str | None = None,
+    azure_openai_api_version: str = "2024-10-21",
     current_date: str | None = None,
     mcp_http_client: httpx.AsyncClient | None = None,
 ) -> Agent:
-    """Compose a ready-to-run reference agent.
+    """Compose a ready-to-run reference agent for the configured LLM provider.
 
-    The returned Agent owns its FoundryChatClient and its MCP tool connection;
-    it is intended to live for the Functions host's lifetime.
-
-    `mcp_http_client` is an advanced seam used by live-integration tests to
-    route the MCP traffic through an in-process ASGI transport; production
-    callers leave it None so AF creates a default httpx client internally.
-    Passing the client at construction time is load-bearing — AF attaches its
-    `header_provider` injection hook to whichever client is set here, so
-    swapping `_httpx_client` post hoc silently drops the Authorization header.
+    The Agent owns its chat client + its MCP tool connection; it is intended
+    to live for the Function App host's lifetime.
     """
-    rendered_date = current_date or date.today().isoformat()
-
-    client = FoundryChatClient(
+    client = _build_chat_client(
+        llm_provider=llm_provider,
         project_endpoint=project_endpoint,
         model=model,
+        azure_openai_endpoint=azure_openai_endpoint,
+        azure_openai_api_version=azure_openai_api_version,
         credential=credential,
     )
 
-    # We own the httpx client so we can attach the bearer hook to every
-    # request (not just call_tool). AF's built-in `header_provider` only fires
-    # during tool invocations and misses the MCP `initialize` handshake, which
-    # our server rejects with 401.
     if mcp_http_client is None:
         mcp_http_client = httpx.AsyncClient(
             follow_redirects=True,
@@ -103,19 +103,76 @@ def build_agent(
         name="crm-mcp",
         url=mcp_url,
         http_client=mcp_http_client,
-        # Our MCP server only serves tools (ADR 0002); it does not implement
-        # the optional `prompts/*` capability. Telling AF to skip prompt
-        # discovery avoids a fatal "Method not found" during `connect()`.
         load_prompts=False,
-        # Slice 3: destructive Dataverse writes are gated behind a user
-        # confirmation. AF surfaces a FunctionApprovalRequestContent in the
-        # response stream; the UI collects the user's yes/no and sends back a
-        # FunctionApprovalResponseContent on the next turn.
         approval_mode={"always_require_approval": ["delete_opportunity"]},
+    )
+
+    rendered_date = current_date or date.today().isoformat()
+    instructions = prompts.render(
+        current_date=rendered_date,
+        provider=llm_provider,
     )
 
     return Agent(
         client=client,
-        instructions=prompts.render(current_date=rendered_date),
+        instructions=instructions,
         tools=[mcp_tool],
+    )
+
+
+def _build_chat_client(
+    *,
+    llm_provider: str,
+    project_endpoint: str,
+    model: str,
+    azure_openai_endpoint: str | None,
+    azure_openai_api_version: str,
+    credential: Any,
+) -> Any:
+    if llm_provider == "foundry":
+        return FoundryChatClient(
+            project_endpoint=project_endpoint,
+            model=model,
+            credential=credential,
+        )
+    if llm_provider in ("azure-openai-global", "azure-openai-cn"):
+        # Lazy import — keeps agent_framework_openai out of the startup path
+        # when the operator isn't using Azure OpenAI.
+        from agent_framework_openai import OpenAIChatClient
+
+        endpoint = azure_openai_endpoint or os.environ.get("AZURE_OPENAI_ENDPOINT")
+        if not endpoint:
+            raise EnvironmentError(
+                f"LLM_PROVIDER={llm_provider!r} requires azure_openai_endpoint "
+                "parameter or AZURE_OPENAI_ENDPOINT environment variable "
+                "(e.g. https://<resource>.openai.azure.com for Global, "
+                "https://<resource>.openai.azure.cn for China)."
+            )
+        return OpenAIChatClient(
+            azure_endpoint=endpoint,
+            model=model,
+            api_version=azure_openai_api_version,
+            credential=credential,
+        )
+    if llm_provider == "custom":
+        dotted = os.environ.get("CUSTOM_LLM_CLIENT_FACTORY")
+        if not dotted:
+            raise EnvironmentError(
+                "LLM_PROVIDER=custom requires CUSTOM_LLM_CLIENT_FACTORY env "
+                "variable set to 'module.path:callable'. The callable must "
+                "take no arguments and return an object implementing AF's "
+                "SupportsChatGetResponse protocol."
+            )
+        module_path, _, attr_name = dotted.partition(":")
+        if not attr_name:
+            raise EnvironmentError(
+                f"CUSTOM_LLM_CLIENT_FACTORY={dotted!r} is malformed — "
+                "expected 'module.path:callable_name'."
+            )
+        module = importlib.import_module(module_path)
+        factory = getattr(module, attr_name)
+        return factory()
+    raise UnsupportedLLMProviderError(
+        f"llm_provider={llm_provider!r} is not supported. "
+        f"Expected one of: {_SUPPORTED_PROVIDERS}."
     )

--- a/src/agent/prompts/loader.py
+++ b/src/agent/prompts/loader.py
@@ -13,28 +13,36 @@ class PromptLoader:
     """Load Markdown prompt files and render them with variable substitution.
 
     Layout (ADR 0006):
-    - `system.zh.md`     — base system prompt (required)
-    - `safety_rules.md`  — destructive-op rules (optional, appended second)
-    - `few_shot/*.md`    — worked examples (optional, appended alphabetically)
+    - `system.zh.md`        — base system prompt (required)
+    - `safety_rules.md`     — destructive-op rules (optional, appended second)
+    - `providers/{name}.md` — per-LLM-provider override (optional; appended when
+                              `render(provider=name)` is given, ADR 0005)
+    - `few_shot/*.md`       — worked examples (optional, appended alphabetically)
     """
 
     SYSTEM_FILE = "system.zh.md"
     SAFETY_FILE = "safety_rules.md"
+    PROVIDERS_DIR = "providers"
     FEW_SHOT_DIR = "few_shot"
 
     def __init__(self, prompts_dir: Path) -> None:
         self._dir = prompts_dir
 
-    def render(self, **variables: str) -> str:
+    def render(self, *, provider: str | None = None, **variables: str) -> str:
         # `{variable}` substitution is restricted to the system prompt file.
-        # safety_rules and few_shot are literal content — JSON examples inside
-        # them legitimately contain braces and must not be reinterpreted.
+        # safety_rules / providers / few_shot are literal content — JSON examples
+        # inside them legitimately contain braces and must not be reinterpreted.
         system = (self._dir / self.SYSTEM_FILE).read_text(encoding="utf-8")
         parts: list[str] = [system.format_map(_StrictMapping(variables))]
 
         safety = self._dir / self.SAFETY_FILE
         if safety.is_file():
             parts.append(safety.read_text(encoding="utf-8"))
+
+        if provider:
+            override = self._dir / self.PROVIDERS_DIR / f"{provider}.md"
+            if override.is_file():
+                parts.append(override.read_text(encoding="utf-8"))
 
         few_shot_dir = self._dir / self.FEW_SHOT_DIR
         if few_shot_dir.is_dir():

--- a/tests/agent/test_builder.py
+++ b/tests/agent/test_builder.py
@@ -64,3 +64,164 @@ def test_build_agent_wires_foundry_client_mcp_tool_and_prompt(tmp_path: Path):
         "update_opportunity",
     ):
         assert non_destructive not in approval.get("always_require_approval", [])
+
+
+# --- Slice 6: LLM provider dispatch -----------------------------------------
+
+
+def _prompts(tmp_path: Path):
+    (tmp_path / "system.zh.md").write_text(
+        "你是 CRM 助手。今天是 {current_date}。", encoding="utf-8"
+    )
+    from agent.prompts.loader import PromptLoader
+
+    return PromptLoader(prompts_dir=tmp_path)
+
+
+def test_build_agent_defaults_to_foundry_when_llm_provider_unset(tmp_path: Path):
+    from agent.builder import build_agent
+    from agent_framework.foundry import FoundryChatClient
+
+    agent = build_agent(
+        project_endpoint="https://proj.services.ai.example",
+        model="gpt-4o-mini",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=_prompts(tmp_path),
+        credential=_fake_credential(),
+        # No llm_provider kwarg — defaults to 'foundry'
+    )
+    assert isinstance(agent.client, FoundryChatClient)
+
+
+def test_build_agent_dispatches_to_azure_openai_global(tmp_path: Path):
+    from agent.builder import build_agent
+    from agent_framework_openai import OpenAIChatClient
+
+    agent = build_agent(
+        llm_provider="azure-openai-global",
+        project_endpoint="ignored-for-openai",
+        model="gpt-4o-mini",
+        azure_openai_endpoint="https://myresource.openai.azure.example",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=_prompts(tmp_path),
+        credential=_fake_credential(),
+    )
+    assert isinstance(agent.client, OpenAIChatClient)
+
+
+def test_build_agent_dispatches_to_azure_openai_cn(tmp_path: Path):
+    from agent.builder import build_agent
+    from agent_framework_openai import OpenAIChatClient
+
+    agent = build_agent(
+        llm_provider="azure-openai-cn",
+        project_endpoint="ignored-for-openai",
+        model="gpt-4o-mini",
+        azure_openai_endpoint="https://myresource.openai.azure.cn",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=_prompts(tmp_path),
+        credential=_fake_credential(),
+    )
+    assert isinstance(agent.client, OpenAIChatClient)
+
+
+def test_build_agent_custom_provider_loads_dotted_path_factory(
+    tmp_path: Path, monkeypatch
+):
+    """CUSTOM_LLM_CLIENT_FACTORY lets a customer inject a provider we never
+    shipped support for — the minimum requirement is that the factory returns
+    a SupportsChatGetResponse-compatible object."""
+    # A test-only module the factory resolves via dotted path.
+    import sys
+    import types
+
+    mod = types.ModuleType("slice6_custom_fixture")
+
+    class _CannedClient:
+        async def get_response(self, messages, *, stream=False, **kwargs):
+            raise NotImplementedError  # runtime is not exercised here
+
+    def factory():
+        return _CannedClient()
+
+    mod.factory = factory
+    sys.modules["slice6_custom_fixture"] = mod
+    monkeypatch.setenv(
+        "CUSTOM_LLM_CLIENT_FACTORY", "slice6_custom_fixture:factory"
+    )
+
+    from agent.builder import build_agent
+
+    agent = build_agent(
+        llm_provider="custom",
+        project_endpoint="n/a",
+        model="n/a",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=_prompts(tmp_path),
+        credential=_fake_credential(),
+    )
+    assert isinstance(agent.client, _CannedClient)
+
+
+def test_build_agent_custom_without_env_var_raises(tmp_path: Path, monkeypatch):
+    """LLM_PROVIDER=custom without CUSTOM_LLM_CLIENT_FACTORY is a
+    misconfiguration the operator should see immediately, not a runtime surprise."""
+    monkeypatch.delenv("CUSTOM_LLM_CLIENT_FACTORY", raising=False)
+
+    from agent.builder import build_agent
+
+    with pytest.raises(EnvironmentError) as excinfo:
+        build_agent(
+            llm_provider="custom",
+            project_endpoint="n/a",
+            model="n/a",
+            mcp_url="http://localhost:7071/mcp",
+            prompts=_prompts(tmp_path),
+            credential=_fake_credential(),
+        )
+    assert "CUSTOM_LLM_CLIENT_FACTORY" in str(excinfo.value)
+
+
+def test_build_agent_unknown_provider_raises_with_full_list(tmp_path: Path):
+    from agent.builder import UnsupportedLLMProviderError, build_agent
+
+    with pytest.raises(UnsupportedLLMProviderError) as excinfo:
+        build_agent(
+            llm_provider="anthropic",
+            project_endpoint="n/a",
+            model="n/a",
+            mcp_url="http://localhost:7071/mcp",
+            prompts=_prompts(tmp_path),
+            credential=_fake_credential(),
+        )
+    message = str(excinfo.value)
+    assert "anthropic" in message
+    for valid in ("foundry", "azure-openai-global", "azure-openai-cn", "custom"):
+        assert valid in message
+
+
+def test_build_agent_forwards_provider_to_prompt_loader(tmp_path: Path):
+    """The per-provider override file is appended to instructions when a
+    non-foundry provider is selected (Slice 6 + ADR 0006 integration)."""
+    (tmp_path / "system.zh.md").write_text("base prompt", encoding="utf-8")
+    providers = tmp_path / "providers"
+    providers.mkdir()
+    (providers / "azure-openai-cn.md").write_text(
+        "CN-specific guidance", encoding="utf-8"
+    )
+
+    from agent.builder import build_agent
+    from agent.prompts.loader import PromptLoader
+
+    agent = build_agent(
+        llm_provider="azure-openai-cn",
+        project_endpoint="n/a",
+        model="gpt-4o-mini",
+        azure_openai_endpoint="https://myresource.openai.azure.cn",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=PromptLoader(prompts_dir=tmp_path),
+        credential=_fake_credential(),
+    )
+    instructions = agent.default_options["instructions"]
+    assert "base prompt" in instructions
+    assert "CN-specific guidance" in instructions

--- a/tests/agent/test_prompts.py
+++ b/tests/agent/test_prompts.py
@@ -53,6 +53,36 @@ def test_prompt_loader_raises_on_unknown_variable(tmp_path: Path):
     assert "user_name" in str(excinfo.value)
 
 
+def test_prompt_loader_appends_provider_override_when_present(tmp_path: Path):
+    """Per-provider override file (prompts/providers/{name}.md) is appended
+    when the caller names the provider; absent file = no-op (provider-neutral)."""
+    (tmp_path / "system.zh.md").write_text("你是 CRM 助手。", encoding="utf-8")
+    providers = tmp_path / "providers"
+    providers.mkdir()
+    (providers / "azure-openai-cn.md").write_text(
+        "CN 模型提示：注意时间用北京时区。", encoding="utf-8"
+    )
+
+    from agent.prompts.loader import PromptLoader
+
+    rendered = PromptLoader(prompts_dir=tmp_path).render(provider="azure-openai-cn")
+    assert "你是 CRM 助手。" in rendered
+    assert "CN 模型提示：注意时间用北京时区。" in rendered
+    assert rendered.index("你是 CRM 助手。") < rendered.index(
+        "CN 模型提示：注意时间用北京时区。"
+    )
+
+
+def test_prompt_loader_ignores_missing_provider_override(tmp_path: Path):
+    (tmp_path / "system.zh.md").write_text("你是 CRM 助手。", encoding="utf-8")
+
+    from agent.prompts.loader import PromptLoader
+
+    # provider="foundry" with no providers/foundry.md must not raise.
+    rendered = PromptLoader(prompts_dir=tmp_path).render(provider="foundry")
+    assert rendered == "你是 CRM 助手。"
+
+
 def test_prompt_loader_appends_few_shot_examples_in_alphabetical_order(tmp_path: Path):
     """Few-shot markdown files under prompts/few_shot/ append after safety_rules."""
     (tmp_path / "system.zh.md").write_text("你是 CRM 助手。", encoding="utf-8")

--- a/tests/integration/test_llm_providers_live.py
+++ b/tests/integration/test_llm_providers_live.py
@@ -1,0 +1,92 @@
+"""Live-integration: LLM provider dispatch end-to-end.
+
+`foundry` is covered by the existing `test_agent_live.py`. This file focuses
+on the dispatcher paths Slice 6 introduces. Each provider's coverage matches
+what a customer can realistically verify:
+
+- `custom` — we install a test fixture that returns a canned
+  SupportsChatGetResponse; exercises dotted-path import + AF acceptance of
+  non-AF chat clients. Runs on every PR (no Azure dep).
+- `azure-openai-global` / `azure-openai-cn` — only exercised if
+  AZURE_OPENAI_ENDPOINT is configured; otherwise skipped with a clear
+  reason. Most customer installs have Foundry OR Azure OpenAI, not both,
+  so this gated path is realistic.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_custom_provider_live_dispatch(monkeypatch):
+    """End-to-end test of the custom dotted-path provider: install a fake
+    factory in sys.modules, build the agent, confirm it uses our instance."""
+    # Build a minimal SupportsChatGetResponse implementation for the test.
+    module = types.ModuleType("slice6_live_fixture")
+
+    class _ProbeClient:
+        probe_ran = False
+
+        async def get_response(self, messages, *, stream=False, **kwargs):
+            _ProbeClient.probe_ran = True
+            raise NotImplementedError  # we're not exercising the runtime loop here
+
+    def factory() -> _ProbeClient:
+        return _ProbeClient()
+
+    module.factory = factory
+    module.ProbeClient = _ProbeClient  # expose for assertion
+    sys.modules["slice6_live_fixture"] = module
+
+    monkeypatch.setenv("CUSTOM_LLM_CLIENT_FACTORY", "slice6_live_fixture:factory")
+
+    from agent.builder import build_agent
+    from agent.prompts.loader import PromptLoader
+
+    prompts_dir = _REPO_ROOT / "src" / "agent" / "prompts"
+    agent = build_agent(
+        llm_provider="custom",
+        project_endpoint="n/a",
+        model="n/a",
+        mcp_url="http://localhost:7071/mcp",
+        prompts=PromptLoader(prompts_dir=prompts_dir),
+        credential=None,
+    )
+    assert isinstance(agent.client, _ProbeClient)
+
+
+async def test_azure_openai_global_live_chat_completion():
+    """Real call against Azure OpenAI on Global. Skipped when
+    AZURE_OPENAI_ENDPOINT is not configured — the author's dev tenant
+    primarily uses Foundry, so this is the realistic gate."""
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+    model = os.environ.get("AZURE_OPENAI_MODEL")
+    if not endpoint or not model:
+        pytest.skip(
+            "AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_MODEL not configured — "
+            "skipping live Azure-OpenAI-Global probe. Set both in .env to "
+            "exercise this path."
+        )
+
+    from agent_framework import Agent, Content, Message
+    from agent_framework_openai import OpenAIChatClient
+    from azure.identity import DefaultAzureCredential
+
+    client = OpenAIChatClient(
+        azure_endpoint=endpoint,
+        model=model,
+        credential=DefaultAzureCredential(),
+    )
+    agent = Agent(client=client, instructions="Reply with OK.")
+    user = Message(role="user", contents=[Content.from_text(text="Ping")])
+    response = await agent.run([user])
+    text = getattr(response, "text", "") or ""
+    assert text, "Azure OpenAI returned an empty response"


### PR DESCRIPTION
Closes #8 — last open slice in PRD #2.

## Summary

`LLM_PROVIDER` now dispatches to four providers behind AF's `SupportsChatGetResponse` protocol:

| Provider | Chat client | Endpoint source |
|---|---|---|
| `foundry` (default) | `FoundryChatClient` | `FOUNDRY_PROJECT_ENDPOINT` |
| `azure-openai-global` | `OpenAIChatClient` | `AZURE_OPENAI_ENDPOINT` (.openai.azure.com) |
| `azure-openai-cn` | `OpenAIChatClient` | `AZURE_OPENAI_ENDPOINT` (.openai.azure.cn) |
| `custom` | customer-supplied | `CUSTOM_LLM_CLIENT_FACTORY` dotted path |

Plus per-provider prompt overrides (`src/agent/prompts/providers/{name}.md`, auto-appended by `PromptLoader`) so CN-specific guidance or model-specific instructions land cleanly without forking the base prompt.

## Why `custom` matters more than it looks

The PRD names four concrete providers but can't predict what Lenovo will actually adopt (Qwen / DeepSeek / Baichuan / a Foundry deployment of some model none of us has heard of yet). `custom` + `CUSTOM_LLM_CLIENT_FACTORY` is the stable extension point: the customer ships 15 lines of Python (a chat client + factory), sets one env var, and their model is in production without any code change in this repo.

README gains an "Adding a new LLM provider" walkthrough showing exactly that.

## Acceptance criteria (#8)

- [x] `LLM_PROVIDER ∈ {foundry, azure-openai-global, azure-openai-cn, custom}` all build an Agent (unit tests assert the right client class per branch)
- [x] Unknown `LLM_PROVIDER` raises `UnsupportedLLMProviderError` listing every valid choice
- [x] `azure-openai-cn` pulls endpoint from env (cloud-specific URL; no cn literal in `src/`)
- [x] `CUSTOM_LLM_CLIENT_FACTORY` resolves a dotted path; failure modes (missing env, malformed `module:attr`) fail loudly with remediation text
- [x] `PromptLoader.render(provider=...)` appends `prompts/providers/{provider}.md` when present; missing file is a no-op
- [x] README "Adding a new LLM provider" shows the minimal `SupportsChatGetResponse` shape + env var registration

## Test plan

- [x] `pytest` → **121 passed + 5 skipped** on Python 3.11.15
  - 9 new unit tests (2 PromptLoader overrides + 7 builder dispatch)
  - 1 new live test: custom-provider dotted path loads a real fixture module (no Azure dep — runs on every PR)
  - 1 new gated live test: Azure OpenAI Global probe, skipped without `AZURE_OPENAI_ENDPOINT`
- [x] Docs-integrity meta-test still green after README changes

## What this closes

With this merge, **every slice in PRD #2** lands:

- ✅ #3 Slice 1 MCP walking skeleton
- ✅ #4 Slice 2 Reference agent (MS AF)
- ✅ #5 Slice 3 Opportunity CRUD + delete approval
- ✅ #6 Slice 4 Search + name resolution
- ✅ #7 Slice 5 CLOUD_ENV=china dual-cloud
- ✅ #9 Slice 7 Skill bundle rewrite
- ✅ #10 Slice 8 Preflight validation
- ✅ #11 Slice 9 Bicep infra + alerts
- ✅ #12 Slice 10 Deployment + operations runbooks
- ⏳ **#8 Slice 6** — this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)